### PR TITLE
Fix isLower and isUpper, re-expose deprecated `isLetter` and `isSpace`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,18 +18,24 @@
 
   These modules are compatible with `base:Data.Char`.
 - Re-export some functions from `Data.Char` in order to make `Unicode.Char`
-  a drop-in replacement.
+  a drop-in replacement in a _future_ version of this package.
 - Drop support for GHC 7.10.3
 
 ### Deprecations
 
-- In `Unicode.Char.General`.
+- In `Unicode.Char.Case`:
 
-  - `isLetter`
-  - `isSpace`
+  - `isUpper`: use `isUpperCase` instead.
+  - `isLower`: use `isLowerCase` instead.
 
-  Preserve the behavior of these functions in `isAlphabetic` and `isWhiteSpace`
-  respectively.
+- In `Unicode.Char.General`:
+
+  - `isLetter`: use `isAlphabetic` instead.
+  - `isSpace`: use `isWhiteSpace` instead.
+
+- In `Unicode.Char`: same as hereinabove. These functions will be replaced in a
+  _future_ release with the functions with the same names from
+  `Unicode.Char.Case.Compat` and `Unicode.Char.General.Compat`.
 
 ## 0.2.0 (November 2021)
 

--- a/README.md
+++ b/README.md
@@ -20,159 +20,95 @@ Machine: 8 × AMD Ryzen 5 2500U on Linux.
 
 ```
 All
-  Unicode.Char.Case
-    isLower
-      base:           OK (1.59s)
-         25 ms ± 583 μs
-      unicode-data:   OK (2.01s)
-        3.9 ms ±  22 μs, 0.15x
-    isUpper
-      base:           OK (1.62s)
-         26 ms ± 1.0 ms
-      unicode-data:   OK (2.00s)
-        3.9 ms ±  24 μs, 0.15x
   Unicode.Char.Case.Compat
+    isLower
+      base:           OK (1.53s)
+         24 ms ± 3.8 ms
+      unicode-data:   OK (2.25s)
+        4.4 ms ±  88 μs, 0.19x
+    isUpper
+      base:           OK (1.50s)
+         24 ms ± 450 μs
+      unicode-data:   OK (2.37s)
+        4.7 ms ± 200 μs, 0.19x
     toLower
-      base:           OK (1.46s)
-         23 ms ± 512 μs
+      base:           OK (1.40s)
+         22 ms ± 1.8 ms
       unicode-data:   OK (1.89s)
-        7.4 ms ± 112 μs, 0.32x
+        7.2 ms ± 297 μs, 0.32x
     toTitle
-      base:           OK (1.49s)
-         24 ms ± 399 μs
-      unicode-data:   OK (1.92s)
-        7.5 ms ±  67 μs, 0.32x
+      base:           OK (1.25s)
+         20 ms ± 2.0 ms
+      unicode-data:   OK (1.65s)
+        6.4 ms ± 509 μs, 0.32x
     toUpper
-      base:           OK (1.46s)
-         23 ms ± 468 μs
-      unicode-data:   OK (1.75s)
-        6.9 ms ±  99 μs, 0.30x
+      base:           OK (1.26s)
+         20 ms ± 2.5 ms
+      unicode-data:   OK (1.72s)
+        6.8 ms ± 335 μs, 0.34x
   Unicode.Char.General
     generalCategory
-      base:           OK (1.95s)
-        129 ms ± 733 μs
-      unicode-data:   OK (1.63s)
-        108 ms ± 1.1 ms, 0.84x
-    isAlphabetic
-      unicode-data:   OK (1.28s)
-        312 μs ± 3.2 μs
+      base:           OK (2.02s)
+        134 ms ± 1.6 ms
+      unicode-data:   OK (1.75s)
+        116 ms ± 1.6 ms, 0.87x
     isAlphaNum
-      base:           OK (1.56s)
-         25 ms ± 252 μs
-      unicode-data:   OK (2.35s)
-        4.6 ms ±  31 μs, 0.19x
-    isControl
-      base:           OK (1.57s)
-         25 ms ± 551 μs
+      base:           OK (1.53s)
+         24 ms ± 1.7 ms
       unicode-data:   OK (2.16s)
-        4.2 ms ±  33 μs, 0.17x
+        4.2 ms ±  29 μs, 0.18x
+    isControl
+      base:           OK (1.47s)
+         23 ms ± 2.6 ms
+      unicode-data:   OK (2.23s)
+        4.4 ms ±  22 μs, 0.19x
     isMark
-      base:           OK (1.63s)
-         26 ms ± 689 μs
-      unicode-data:   OK (2.34s)
-        4.6 ms ±  27 μs, 0.18x
+      base:           OK (1.47s)
+         23 ms ± 624 μs
+      unicode-data:   OK (2.28s)
+        4.5 ms ±  48 μs, 0.19x
     isPrint
-      base:           OK (1.62s)
-         26 ms ± 788 μs
-      unicode-data:   OK (2.13s)
-        4.2 ms ±  73 μs, 0.16x
+      base:           OK (1.53s)
+         25 ms ± 2.4 ms
+      unicode-data:   OK (2.27s)
+        4.4 ms ±  50 μs, 0.18x
     isPunctuation
-      base:           OK (1.61s)
-         26 ms ± 170 μs
-      unicode-data:   OK (2.04s)
-        4.0 ms ±  30 μs, 0.16x
+      base:           OK (1.51s)
+         24 ms ± 459 μs
+      unicode-data:   OK (2.24s)
+        4.4 ms ±  25 μs, 0.18x
     isSeparator
-      base:           OK (1.71s)
-         27 ms ± 247 μs
-      unicode-data:   OK (2.20s)
-        4.3 ms ±  25 μs, 0.16x
+      base:           OK (1.52s)
+         24 ms ± 407 μs
+      unicode-data:   OK (2.43s)
+        4.8 ms ±  94 μs, 0.20x
     isSymbol
-      base:           OK (1.68s)
-         27 ms ± 312 μs
-      unicode-data:   OK (2.32s)
-        4.5 ms ±  41 μs, 0.17x
-    isWhiteSpace
-      unicode-data:   OK (1.28s)
-        312 μs ± 3.5 μs
-    isHangul
-      unicode-data:   OK (1.28s)
-        312 μs ± 2.6 μs
-    isHangulLV
-      unicode-data:   OK (1.28s)
-        312 μs ± 2.8 μs
-    isJamo
-      unicode-data:   OK (1.28s)
-        312 μs ± 2.7 μs
-    jamoLIndex
-      unicode-data:   OK (1.28s)
-        312 μs ± 3.1 μs
-    jamoVIndex
-      unicode-data:   OK (1.28s)
-        312 μs ± 2.9 μs
-    jamoTIndex
-      unicode-data:   OK (1.28s)
-        312 μs ± 2.9 μs
+      base:           OK (1.49s)
+         24 ms ± 863 μs
+      unicode-data:   OK (1.34s)
+        5.2 ms ±  92 μs, 0.22x
   Unicode.Char.General.Compat
     isAlpha
-      base:           OK (1.59s)
-         25 ms ± 446 μs
+      base:           OK (1.46s)
+         23 ms ± 322 μs
       unicode-data:   OK (2.14s)
-        4.2 ms ±  25 μs, 0.17x
+        4.1 ms ±  36 μs, 0.18x
     isLetter
-      base:           OK (1.72s)
-         27 ms ± 677 μs
-      unicode-data:   OK (2.14s)
-        4.2 ms ±  59 μs, 0.15x
+      base:           OK (1.44s)
+         22 ms ± 640 μs
+      unicode-data:   OK (2.17s)
+        4.3 ms ±  58 μs, 0.19x
     isSpace
-      base:           OK (1.48s)
-         12 ms ±  99 μs
-      unicode-data:   OK (2.30s)
-        4.5 ms ±  30 μs, 0.39x
-  Unicode.Char.Identifiers
-    isIDContinue
-      unicode-data:   OK (1.28s)
-        312 μs ± 2.7 μs
-    isIDStart
-      unicode-data:   OK (1.29s)
-        312 μs ± 2.7 μs
-    isXIDContinue
-      unicode-data:   OK (1.28s)
-        312 μs ± 3.2 μs
-    isXIDStart
-      unicode-data:   OK (1.28s)
-        312 μs ± 3.2 μs
-    isPatternSyntax
-      unicode-data:   OK (1.28s)
-        312 μs ± 3.4 μs
-    isPatternWhitespace
-      unicode-data:   OK (1.28s)
-        312 μs ± 2.9 μs
-  Unicode.Char.Normalization
-    isCombining
-      unicode-data:   OK (1.28s)
-        313 μs ± 5.1 μs
-    combiningClass
-      unicode-data:   OK (1.66s)
-        3.2 ms ± 113 μs
-    isCombiningStarter
-      unicode-data:   OK (1.29s)
-        312 μs ± 3.2 μs
-    isDecomposable
-      Canonical
-        unicode-data: OK (1.29s)
-          312 μs ± 3.5 μs
-      Kompat
-        unicode-data: OK (1.28s)
-          312 μs ± 3.5 μs
-    decomposeHangul
-      unicode-data:   OK (1.28s)
-        312 μs ± 3.0 μs
+      base:           OK (1.44s)
+         11 ms ± 1.2 ms
+      unicode-data:   OK (1.36s)
+        5.3 ms ± 243 μs, 0.49x
   Unicode.Char.Numeric
     isNumber
-      base:           OK (1.66s)
-         26 ms ± 404 μs
-      unicode-data:   OK (2.47s)
-        4.8 ms ±  22 μs, 0.18x
+      base:           OK (1.52s)
+         24 ms ± 368 μs
+      unicode-data:   OK (2.41s)
+        4.7 ms ±  41 μs, 0.19x
 ```
 
 ## Unicode database version update

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -20,17 +20,23 @@ data Bench a = Bench
 main :: IO ()
 main = defaultMain
   [ bgroup "Unicode.Char.Case"
-    [ bgroup' "isLower"
-      [ Bench "base"         B.isLower
-      , Bench "unicode-data" C.isLower
+    [ bgroup "isLowerCase"
+      [ benchNF "unicode-data" C.isLowerCase
       ]
-    , bgroup' "isUpper"
-      [ Bench "base"         B.isUpper
-      , Bench "unicode-data" C.isUpper
+    , bgroup "isUpperCase"
+      [ benchNF "unicode-data" C.isUpperCase
       ]
     ]
   , bgroup "Unicode.Char.Case.Compat"
-    [ bgroup' "toLower"
+    [ bgroup' "isLower"
+      [ Bench "base"         B.isLower
+      , Bench "unicode-data" CC.isLower
+      ]
+    , bgroup' "isUpper"
+      [ Bench "base"         B.isUpper
+      , Bench "unicode-data" CC.isUpper
+      ]
+    , bgroup' "toLower"
       [ Bench "base"         B.toLower
       , Bench "unicode-data" CC.toLower
       ]

--- a/lib/Unicode/Char.hs
+++ b/lib/Unicode/Char.hs
@@ -43,7 +43,7 @@ where
 
 import Data.Char (chr, ord)
 import Data.Version (Version, makeVersion)
-import Unicode.Char.Case
+import Unicode.Char.Case hiding (isLower, isUpper)
 import Unicode.Char.Case.Compat
 import Unicode.Char.General hiding (isLetter, isSpace)
 import Unicode.Char.General.Compat

--- a/lib/Unicode/Char.hs
+++ b/lib/Unicode/Char.hs
@@ -43,10 +43,10 @@ where
 
 import Data.Char (chr, ord)
 import Data.Version (Version, makeVersion)
-import Unicode.Char.Case hiding (isLower, isUpper)
-import Unicode.Char.Case.Compat
-import Unicode.Char.General hiding (isLetter, isSpace)
-import Unicode.Char.General.Compat
+import Unicode.Char.Case
+import Unicode.Char.Case.Compat hiding (isLower, isUpper)
+import Unicode.Char.General
+import Unicode.Char.General.Compat hiding (isLetter, isSpace)
 import Unicode.Char.Identifiers
 import Unicode.Char.Numeric
 import Unicode.Char.Normalization

--- a/lib/Unicode/Char/Case.hs
+++ b/lib/Unicode/Char/Case.hs
@@ -8,7 +8,10 @@
 -- Case and case mapping related functions.
 --
 module Unicode.Char.Case
-    ( isLower
+    ( -- * Predicates
+      isLowerCase
+    , isLower
+    , isUpperCase
     , isUpper
     )
 where
@@ -17,19 +20,30 @@ import qualified Unicode.Internal.Char.DerivedCoreProperties as P
 
 -- | Returns 'True' for lower-case letters.
 --
--- prop> isLower c == Data.Char.isLower c
+-- @since 0.3.0
+{-# INLINE isLowerCase #-}
+isLowerCase :: Char -> Bool
+isLowerCase = P.isLowercase
+
+-- | Returns 'True' for lower-case letters.
 --
 -- @since 0.1.0
 {-# INLINE isLower #-}
+{-# DEPRECATED isLower "Use isLowerCase instead. Note that the behavior of this function does not match base:Data.Char.isLower. See Unicode.Char.Case.Compat for behavior compatible with base:Data.Char." #-}
 isLower :: Char -> Bool
 isLower = P.isLowercase
 
--- | Returns 'True' for upper-case or title-case letters.  Title case is used by
--- a small number of letter ligatures like the single-character form of /Lj/.
+-- | Returns 'True' for upper-case letters.
 --
--- prop> isUpper c == Data.Char.isUpper c
+-- @since 0.3.0
+{-# INLINE isUpperCase #-}
+isUpperCase :: Char -> Bool
+isUpperCase = P.isUppercase
+
+-- | Returns 'True' for upper-case letters.
 --
 -- @since 0.1.0
 {-# INLINE isUpper #-}
+{-# DEPRECATED isUpper "Use isUpperCase instead. Note that the behavior of this function does not match base:Data.Char.isUpper. See Unicode.Char.Case.Compat for behavior compatible with base:Data.Char." #-}
 isUpper :: Char -> Bool
 isUpper = P.isUppercase

--- a/lib/Unicode/Char/Case/Compat.hs
+++ b/lib/Unicode/Char/Case/Compat.hs
@@ -12,14 +12,42 @@
 -- therefore they are placed in a separate module in order to avoid ambiguity.
 --
 module Unicode.Char.Case.Compat
-    ( toUpper
+    ( -- * Predicates
+      isUpper
+    , isLower
+      -- * Case conversion
+    , toUpper
     , toLower
     , toTitle
     ) where
 
+import Unicode.Char.General (GeneralCategory(..), generalCategory)
 import qualified Unicode.Internal.Char.UnicodeData.SimpleLowerCaseMapping as C
 import qualified Unicode.Internal.Char.UnicodeData.SimpleTitleCaseMapping as C
 import qualified Unicode.Internal.Char.UnicodeData.SimpleUpperCaseMapping as C
+
+-- | Selects upper-case or title-case alphabetic Unicode characters (letters).
+-- Title case is used by a small number of letter ligatures like the
+-- single-character form of /Lj/.
+--
+-- prop> isUpper c == Data.Char.isUpper c
+--
+-- @since 0.3.0
+isUpper :: Char -> Bool
+isUpper c = case generalCategory c of
+    UppercaseLetter -> True
+    TitlecaseLetter -> True
+    _               -> False
+
+-- | Selects lower-case alphabetic Unicode characters (letters).
+--
+-- prop> isLower c == Data.Char.isLower c
+--
+-- @since 0.3.0
+isLower :: Char -> Bool
+isLower c = case generalCategory c of
+    LowercaseLetter -> True
+    _               -> False
 
 -- | Convert a letter to the corresponding upper-case letter, if any.
 -- Any other character is returned unchanged.

--- a/lib/Unicode/Char/General.hs
+++ b/lib/Unicode/Char/General.hs
@@ -431,7 +431,9 @@ isSymbol c = case generalCategory c of
     OtherSymbol    -> True
     _              -> False
 
--- | Returns 'True' for alphabetic Unicode characters.
+-- | Returns 'True' for alphabetic Unicode characters (lower-case, upper-case
+-- and title-case letters, plus letters of caseless scripts and modifiers
+-- letters).
 --
 -- @since 0.1.0
 {-# INLINE isLetter #-}

--- a/test/Unicode/CharSpec.hs
+++ b/test/Unicode/CharSpec.hs
@@ -7,6 +7,12 @@ module Unicode.CharSpec
 
 import qualified Data.Char as Char
 import qualified Unicode.Char as UChar
+-- [TODO] Remove the following qualified imports once isLetter and isSpace
+--        are removed from Unicode.Char.General
+import qualified Unicode.Char.General.Compat as UCharCompat
+-- [TODO] Remove the following qualified imports once isUpper and isLower
+--        are removed from Unicode.Char.Case
+import qualified Unicode.Char.Case.Compat as UCharCompat
 import Data.Foldable (traverse_)
 import Test.Hspec
 
@@ -45,7 +51,7 @@ spec = do
     it "isControl" do
       UChar.isControl `shouldBeEqualTo` Char.isControl
     it "isLetter" do
-      UChar.isLetter `shouldBeEqualTo` Char.isLetter
+      UCharCompat.isLetter `shouldBeEqualTo` Char.isLetter
     it "isMark" do
       UChar.isMark `shouldBeEqualTo` Char.isMark
     it "isNumber" do
@@ -57,14 +63,14 @@ spec = do
     it "isSeparator" do
       UChar.isSeparator `shouldBeEqualTo` Char.isSeparator
     it "isSpace" do
-      UChar.isSpace `shouldBeEqualTo` Char.isSpace
+      UCharCompat.isSpace `shouldBeEqualTo` Char.isSpace
     it "isSymbol" do
       UChar.isSymbol `shouldBeEqualTo` Char.isSymbol
   describe' "Case" do
     it "isLower" do
-      UChar.isLower `shouldBeEqualTo` Char.isLower
+      UCharCompat.isLower `shouldBeEqualTo` Char.isLower
     it "isUpper" do
-      UChar.isUpper `shouldBeEqualTo` Char.isUpper
+      UCharCompat.isUpper `shouldBeEqualTo` Char.isUpper
     it "toLower" do
       UChar.toLower `shouldBeEqualTo` Char.toLower
     it "toUpper" do

--- a/test/Unicode/CharSpec.hs
+++ b/test/Unicode/CharSpec.hs
@@ -61,11 +61,9 @@ spec = do
     it "isSymbol" do
       UChar.isSymbol `shouldBeEqualTo` Char.isSymbol
   describe' "Case" do
-    let it' t = before_ (pendingWith "Incompatible implementation with Data.Char")
-              . it t
-    it' "isLower" do
+    it "isLower" do
       UChar.isLower `shouldBeEqualTo` Char.isLower
-    it' "isUpper" do
+    it "isUpper" do
       UChar.isUpper `shouldBeEqualTo` Char.isUpper
     it "toLower" do
       UChar.toLower `shouldBeEqualTo` Char.toLower


### PR DESCRIPTION
There are issues with current `isUpper` and `isLower`:
- They are not compatible with `Data.Char`
- `Unicode.Char.Case.isUpper` matches only _upper_-cased letters, not _title_-cased letters.

This PR:
- adds new predicates `isUpperCase` and `isLowerCase`.
- deprecates previous  `isUpper` and `isLower` and fix their doc.
- adds `base`-compatible `isUpper` and `isLower` to `Unicode.Char.Case.Compat`.
- re-exposes now deprecated `isLetter` and `isSpace` in order to give time for the transition.
- adds tests to ensure `base` compatibility.
- updates benchmark
