### PR TITLE
Relax upper bound for base, allowing base-4.17.*

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -51,6 +51,7 @@ jobs:
           - 8.10.7+exe
           - 9.0.1+exe
           - 9.2.1
+          - 9.4.2
           - hlint
 
         include:
@@ -102,6 +103,11 @@ jobs:
             ghc_version: 9.2.1
             runner: ubuntu-latest
             cabal_version: 3.6
+
+          - name: 9.4.2
+            ghc_version: 9.4.2
+            runner: ubuntu-latest
+            cabal_version: 3.8.1.0
 
           - name: hlint
             pack_options: HLINT_OPTIONS="lint" HLINT_TARGETS="lib exe"

--- a/unicode-data-names/unicode-data-names.cabal
+++ b/unicode-data-names/unicode-data-names.cabal
@@ -28,6 +28,7 @@ tested-with:         GHC==8.0.2
                    , GHC==8.10.7
                    , GHC==9.0.1
                    , GHC==9.2.1
+                   , GHC==9.4.2
 
 extra-source-files:
     Changelog.md
@@ -82,7 +83,7 @@ library
 
   hs-source-dirs: lib
   build-depends:
-      base             >= 4.7   && < 4.17
+      base             >= 4.7   && < 4.18
 
 test-suite test
   import: default-extensions, compile-options
@@ -93,7 +94,7 @@ test-suite test
   other-modules:
       Unicode.Char.General.NamesSpec
   build-depends:
-      base             >= 4.7   && < 4.17
+      base             >= 4.7   && < 4.18
     , hspec            >= 2.0   && < 2.10
     , unicode-data
     , unicode-data-names
@@ -122,7 +123,7 @@ benchmark bench
   hs-source-dirs: bench
   main-is: Main.hs
   build-depends:
-    base        >= 4.7   && < 4.17,
+    base        >= 4.7   && < 4.18,
     deepseq     >= 1.1   && < 1.5,
     tasty-bench >= 0.2.5 && < 0.4,
     tasty       >= 1.4.1,

--- a/unicode-data/unicode-data.cabal
+++ b/unicode-data/unicode-data.cabal
@@ -28,6 +28,7 @@ tested-with:         GHC==8.0.2
                    , GHC==8.10.7
                    , GHC==9.0.1
                    , GHC==9.2.1
+                   , GHC==9.4.2
 
 extra-source-files:
     Changelog.md
@@ -107,7 +108,7 @@ library
   hs-source-dirs: lib
   ghc-options: -O2
   build-depends:
-      base >=4.7 && <4.17
+      base >=4.7 && <4.18
 
 executable ucd2haskell
   import: default-extensions, compile-options
@@ -119,7 +120,7 @@ executable ucd2haskell
   if flag(ucd2haskell)
     buildable: True
     build-depends:
-        base             >= 4.7   && < 4.17
+        base             >= 4.7   && < 4.18
       , containers       >= 0.5   && < 0.7
       , directory        >= 1.3.6 && < 1.3.7
       , getopt-generics  >= 0.13  && < 0.14
@@ -136,7 +137,7 @@ test-suite test
   other-modules:
       Unicode.CharSpec
   build-depends:
-      base             >= 4.7   && < 4.17
+      base             >= 4.7   && < 4.18
     , hspec            >= 2.0   && < 2.10
     , unicode-data
   build-tool-depends:
@@ -153,7 +154,7 @@ benchmark bench
   hs-source-dirs: bench
   main-is: Main.hs
   build-depends:
-    base        >= 4.7   && < 4.17,
+    base        >= 4.7   && < 4.18,
     deepseq     >= 1.1   && < 1.5,
     tasty-bench >= 0.2.5 && < 0.4,
     tasty       >= 1.4.1,


### PR DESCRIPTION
This allows to build with GHC 9.4.