### PR TITLE
Bump the upper bound of tasty-bench

### DIFF
--- a/experimental/unicode-data-text/unicode-data-text.cabal
+++ b/experimental/unicode-data-text/unicode-data-text.cabal
@@ -95,7 +95,7 @@ benchmark bench
   build-depends:
     base             >= 4.7   && < 4.21,
     deepseq          >= 1.1   && < 1.6,
-    tasty-bench      >= 0.2.5 && < 0.4,
+    tasty-bench      >= 0.2.5 && < 0.5,
     tasty            >= 1.4.1 && < 1.6,
     text             >= 1.2.4 && < 2.2,
     unicode-data     >= 0.6   && < 0.7,

--- a/unicode-data-names/unicode-data-names.cabal
+++ b/unicode-data-names/unicode-data-names.cabal
@@ -175,7 +175,7 @@ benchmark bench
   build-depends:
     base         >= 4.7   && < 4.21,
     deepseq      >= 1.1   && < 1.6,
-    tasty-bench  >= 0.2.5 && < 0.4,
+    tasty-bench  >= 0.2.5 && < 0.5,
     tasty        >= 1.4.1 && < 1.6,
     unicode-data >= 0.6   && < 0.7,
     unicode-data-names

--- a/unicode-data-scripts/unicode-data-scripts.cabal
+++ b/unicode-data-scripts/unicode-data-scripts.cabal
@@ -120,7 +120,7 @@ benchmark bench
   build-depends:
     base        >= 4.7   && < 4.21,
     deepseq     >= 1.1   && < 1.6,
-    tasty-bench >= 0.2.5 && < 0.4,
+    tasty-bench >= 0.2.5 && < 0.5,
     tasty       >= 1.4.1 && < 1.6,
     unicode-data-scripts
   if impl(ghc < 9.0)

--- a/unicode-data-security/unicode-data-security.cabal
+++ b/unicode-data-security/unicode-data-security.cabal
@@ -111,7 +111,7 @@ benchmark bench
   build-depends:
     base        >= 4.7   && < 4.21,
     deepseq     >= 1.1   && < 1.6,
-    tasty-bench >= 0.2.5 && < 0.4,
+    tasty-bench >= 0.2.5 && < 0.5,
     tasty       >= 1.4.1,
     unicode-data-security
   -- [NOTE] Recommendation of tasty-bench to reduce garbage collection noisiness

--- a/unicode-data/unicode-data.cabal
+++ b/unicode-data/unicode-data.cabal
@@ -161,7 +161,7 @@ benchmark bench
   build-depends:
     base        >= 4.7   && < 4.21,
     deepseq     >= 1.1   && < 1.6,
-    tasty-bench >= 0.2.5 && < 0.4,
+    tasty-bench >= 0.2.5 && < 0.5,
     tasty       >= 1.4.1 && < 1.6,
     unicode-data
   if impl(ghc < 9.0)


### PR DESCRIPTION
From the Changelog of `tasty-bench`. I don't see any behavioural changes we must be concerned about.
I'll make a revision on hackage once this is merged.

See: https://github.com/commercialhaskell/stackage/issues/7480 